### PR TITLE
Add Cardinality to tooltip inside scripted_function conditions

### DIFF
--- a/common/scripted_functions.cwt
+++ b/common/scripted_functions.cwt
@@ -8,6 +8,7 @@ types = {
 scripted_function = {
 	## cardinality = 0..1
 	condition = {
+		## cardinality = 0..1
 		tooltip = localisation
 		potential = {
 			alias_name[trigger] = alias_match_left[trigger]


### PR DESCRIPTION
I found ```can_expel_minority_from = {
	condition = {
		potential = {
			OR = {
				is_religious_center_province = yes
				is_reformation_center = yes
			}
		}
		allow = {
			always = no
		}
	}
}``` in 00_scripted_functions.txt and thought this needed to be updated.